### PR TITLE
Fix jamming slider number update

### DIFF
--- a/custom_components/rfplayer/number.py
+++ b/custom_components/rfplayer/number.py
@@ -50,3 +50,4 @@ class RfplayerJammingNumber(RfplayerDevice, NumberEntity):
         rfplayer = self.hass.data[DOMAIN][RFPLAYER_PROTOCOL]
         await rfplayer.send_command_ack(command=int(value), protocol=self._protocol)
         self._state = value
+        self.async_write_ha_state()


### PR DESCRIPTION
Without this function call when we move the slider the value next to the slider is not updated.

Idea taken from HA input_number component code.

This seems top also let the value be restored after an HA restart.