### PR TITLE
Update rfpprotocol.py

### DIFF
--- a/custom_components/rfplayer/rflib/rfpprotocol.py
+++ b/custom_components/rfplayer/rflib/rfpprotocol.py
@@ -157,17 +157,7 @@ class PacketHandling(ProtocolBase):
         device_id: str = None,
     ) -> None:
         """Send device command to rfplayer gateway."""
-        if device_id is not None:
-            if protocol == "EDISIOFRAME" :
-                self.send_raw_packet(f"ZIA++{protocol} {device_id}")
-            else :
-                self.send_raw_packet(f"ZIA++{command} {protocol} ID {device_id}")
-        elif device_address is not None:
-            self.send_raw_packet(f"ZIA++{command} {protocol} {device_address}")
-        elif protocol == "EDISIOFRAME":
-            self.send_raw_packet(f"ZIA++{command}")
-        else:
-            self.send_raw_packet(f"ZIA++{protocol} {command}")
+         self.send_raw_packet(f"ZIA++{command} {device_address} {protocol}") #ATTENTION AU FORMAT DE LA COMMANDE !
 
 class CommandSerialization(PacketHandling):
     """Logic for ensuring asynchronous commands are sent in order."""


### PR DESCRIPTION
Modification de la méthode d'envoie, suivant doc API. 
La partie `command` devient la vraie commande `Command name` 
La partie `device_address`  devient la vraie adresse ( ou ID) pour le Rfplayer ,une partie de `parameters`
La partie `protocol` devient la suite `parameters` si besoin.

La partie `device_id` devient le vrai nom pour HA .
Nota : modification du services.yaml pour précision de ce changement ?