### PR TITLE
Fixups gce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.1
 
 - Fix mixup between device ID and device address in english for send_command service
+- Fix RfplayerDevice available getter
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.7.1
+
+- Fix mixup between device ID and device address in english for send_command service
+
 ## 0.7.0
 
 - Fix default conf missing error during initialization

--- a/custom_components/rfplayer/__init__.py
+++ b/custom_components/rfplayer/__init__.py
@@ -349,7 +349,7 @@ class RfplayerDevice(RestoreEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return bool(self._protocol)
+        return bool(self._available)
 
     @callback
     def _availability_callback(self, availability) -> None:

--- a/custom_components/rfplayer/switch.py
+++ b/custom_components/rfplayer/switch.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
 
 
 class RfplayerSwitch(RfplayerDevice, SwitchEntity):
-    """Representation of a Rfplayer sensor."""
+    """Representation of a Rfplayer switch."""
 
     # pylint: disable-next=too-many-arguments
     def __init__(

--- a/custom_components/rfplayer/translations/en.json
+++ b/custom_components/rfplayer/translations/en.json
@@ -47,11 +47,11 @@
           "name": "Command"
         },
         "device_address": {
-          "description": "Exclusive with device ID (eg 1).",
+          "description": "Exclusive with device address (eg A1).",
           "name": "Device address"
         },
         "device_id": {
-          "description": "Exclusive with device address (eg A1).",
+          "description": "Exclusive with device ID (eg 1).",
           "name": "Device ID"
         },
         "protocol": {


### PR DESCRIPTION
A few seemingly obvious fixups from abandoned PR #47.
I keep them separate as they are unrelated to each other.

About the available function, I guess you know what was the intent as it dates back to your initial commit (ie was returning self._protocol instead of self._available). But seems logical this was a mistake.